### PR TITLE
add "anti overflow" mode for YMA encoding

### DIFF
--- a/yma_codec.h
+++ b/yma_codec.h
@@ -14,8 +14,9 @@
  * Given (len) amount of PCM samples in buffer,
  * return encoded ADPCM samples in outbuffer.
  * Output buffer should be at least (len/2) elements large.
+ * Set anti_overflow to 1 to prevent overflows in the encoded data.
  */
-void yma_encode(int16_t *buffer,uint8_t *outbuffer,long len);
+void yma_encode(int16_t *buffer,uint8_t *outbuffer,long len, uint8_t anti_overflow);
 
 /**
  * Given ADPCM samples in (buffer), return (len) amount of


### PR DESCRIPTION
This adds an option `-a` that prevents a signal overflow when encoding YM-ADPCM-A data.  
By default there is no overflow protection. You have to specify the option to enable it.

Closes #6 

I used a sine and a square wave with maximum amplitude to test the code: [YM-ADPCM-A-Test.zip](https://github.com/user-attachments/files/24162800/YM-ADPCM-A-Test.zip)

I'm open for suggestions regarding the proper naming of the mode.
